### PR TITLE
Use content of the variable 'description' as WorkingDirectory

### DIFF
--- a/templates/default/bootapp.service.erb
+++ b/templates/default/bootapp.service.erb
@@ -6,7 +6,7 @@ After=syslog.target
 User=<%= @user %>
 ExecStart=/usr/bin/java <%= @java_opts %> -jar <%= @jar_path %> --server.port=<%= @port %> --logging.path=<%= @logging_directory %> <%= @boot_opts %>
 SuccessExitStatus=143
-WorkingDirectory=/opt/spring-boot/<%= @new_resource_name %>
+WorkingDirectory=/opt/spring-boot/<%= @description %>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The variable 'description' has the name of the spring-boot-service as its value. So we can use it to add a proper WorkingDirectory to the systemd service configuration. The logs subdirectory will no be created in /opt/spring-boot/appX/ and not in /opt/spring-boot/.